### PR TITLE
Fix gamemode listed for Insanihe

### DIFF
--- a/src/data/maps/overcast.json
+++ b/src/data/maps/overcast.json
@@ -2984,7 +2984,7 @@
             "authors": [
                 {"username": "Obelistics", "uuid": "b03360db-b8cd-49de-8ba1-b7920c2238a9"}
             ],
-            "tags": ["dtc"],
+            "tags": ["dtm"],
             "commercial": true,
             "download": true,
             "xml": true


### PR DESCRIPTION
Gamemode is listed as `dtc` however the map contains only monuments hence `dtm`.