### PR TITLE
Fix display name (and slug?) of Aerobellum

### DIFF
--- a/src/data/maps/overcast.json
+++ b/src/data/maps/overcast.json
@@ -6704,8 +6704,8 @@
             "download": true,
             "xml": true
         }, {
-            "name": "Arobellum",
-            "slug": "arobellum",
+            "name": "Aerobellum",
+            "slug": "aerobellum",
             "authors": [
                 {"username": "StealthMedia", "uuid": "2a289d2a-d970-49c5-9a6c-01fc0264e317"}
             ],


### PR DESCRIPTION
This edit also changes the slug. I'm guessing https://github.com/MCResourcePile/overcast-maps/tree/master/maps/arobellum 's folder name also needs to be changed, but I lack the knowledge in how to do so.