### PR TITLE
Add XML include file dependencies in download panel

### DIFF
--- a/src/assets/js/maps-redux.js
+++ b/src/assets/js/maps-redux.js
@@ -121,6 +121,25 @@ function populateDownloadModal(id) {
     });
   });
 
+  document.querySelectorAll('[data-populate="includes"]').forEach(node => {
+    node.innerHTML = "";
+    document.getElementById('mr-map-includes').classList.add('d-none');
+  });
+  if (map.source.includes) {
+    document.getElementById('mr-map-includes').classList.remove('d-none');
+    map.source.includes.files.forEach(file => {
+      var includeEl = document.createElement('a');
+      includeEl.setAttribute('href', `${map.source.includes.root}/${file}`);
+      includeEl.setAttribute('class', 'mr-include');
+      includeEl.setAttribute('target', '_blank');
+      includeEl.innerHTML = file;
+
+      document.querySelectorAll('[data-populate="includes"]').forEach(node => {
+        node.appendChild(includeEl.cloneNode(true));
+      });
+    });
+  }
+
   document.querySelectorAll('[data-populate="license-name"]').forEach(node => {
     node.innerHTML = license.name;
 

--- a/src/assets/js/maps-redux.js
+++ b/src/assets/js/maps-redux.js
@@ -121,7 +121,16 @@ function populateDownloadModal(id) {
     });
   });
 
-  populateElementContent("license-name", license.name);
+  document.querySelectorAll('[data-populate="license-name"]').forEach(node => {
+    node.innerHTML = license.name;
+
+    if (license.human_readable_url) {
+      var linkEl = document.createElement('a');
+      linkEl.setAttribute('href', license.human_readable_url);
+      linkEl.setAttribute('target', '_blank');
+      node.appendChild(linkEl.cloneNode(true));
+    };
+  });
   populateElementContent("license-description", license.description);
 
   document.querySelectorAll('[data-populate="license-permissions"]').forEach(node => {

--- a/src/assets/scss/_maps_redux.scss
+++ b/src/assets/scss/_maps_redux.scss
@@ -290,7 +290,7 @@
 
   p {
     font-size: 1rem;
-    margin: 0;
+    line-height: normal;
 
     &.card-text {
       margin-bottom: 1rem;
@@ -335,6 +335,12 @@
   .mr-license-title {
     font-family: 'Montserrat', sans-serif;
     font-weight: bold;
+
+    a::after {
+      font-family: "Font Awesome 5 Free";
+      content: "\f35d";
+      margin-left: .5rem;
+    }
   }
 
   .mr-license-description {
@@ -344,6 +350,10 @@
   .mr-license-disclaimer {
     font-size: 12px;
     margin-top: .5rem;
+    margin-bottom: 0;
+  }
+
+  p {
     margin-bottom: 0;
   }
 

--- a/src/assets/scss/_maps_redux.scss
+++ b/src/assets/scss/_maps_redux.scss
@@ -269,6 +269,30 @@
   }
 }
 
+.mr-includes {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 4px;
+
+  .mr-include {
+    font-size: 12px;
+    background-color: rgba(240, 240, 240, 1);
+    padding: 1px 8px;
+    border-radius: .25rem;
+    white-space: nowrap;
+    color: #1c1c1c;
+    font-family: monospace;
+
+    &::before {
+      font-family: "Font Awesome 5 Free";
+      content: "\f1c9";
+      font-weight: 900;
+      margin-right: .5rem;
+    }
+  }
+}
+
 .mr-modal {
   .mr-modal-title {
     font-family: 'Montserrat', sans-serif;
@@ -328,8 +352,6 @@
     }
   }
 }
-
-
 
 .mr-license {
   .mr-license-title {
@@ -512,6 +534,13 @@
       &[data-color="white"] {
         --team-color: #fff;
       }
+    }
+  }
+
+  .mr-includes {
+    .mr-include {
+      background-color: rgba(82, 82, 82, 0.85);
+      color: #fff;
     }
   }
 

--- a/src/partials/pages/maps_redux/components/maps_redux_modal_download.html
+++ b/src/partials/pages/maps_redux/components/maps_redux_modal_download.html
@@ -9,7 +9,7 @@
         <div class="mr-authors mb-3 justify-content-start" data-populate="authors"></div>
         <div class="container-fluid">
           <div class="row mb-3">
-            <div class="col-12 col-lg-6 px-0 pr-lg-3">
+            <div class="col-12 col-lg-6 px-0 pr-lg-3 mb-1 mb-lg-0">
               <h6>Objective</h6>
               <p data-populate="objective"></p>
             </div>
@@ -20,6 +20,11 @@
             <div class="col-6 col-lg-3 pr-0">
               <h6>Tags</h6>
               <div class="mr-tags mr-tags-top" data-populate="tags"></div>
+            </div>
+            <div class="col-12 col-lg-6 px-0 pr-lg-3 mt-1" id="mr-map-includes">
+              <h6>XML Includes</h6>
+              <p>This map has external XML dependencies that must be included on your PGM server in order to be loaded.</p>
+              <div data-populate="includes" class="mr-includes"></div>
             </div>
           </div>
           <div class="modal-inner-card mr-license row mb-3">
@@ -66,10 +71,10 @@
       </div>
       <div class="modal-footer">
         <div id="mr-download-progress" class="w-100" style="display:none;">
-            <b>Your download will begin shortly...</b>
-            <div class="progress" style="margin-top:8px;margin-bottom:16px;">
-                <div id="compile-progress" class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
-            </div>
+          <b>Your download will begin shortly...</b>
+          <div class="progress" style="margin-top:8px;margin-bottom:16px;">
+            <div id="compile-progress" class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
+          </div>
         </div>
         <div id="mr-download-controls" class="w-100">
           <div class="d-flex flex-row justify-content-between w-100">


### PR DESCRIPTION
Resolves https://github.com/MCResourcePile/mcresourcepile.github.io/issues/198 in conjunction with https://github.com/MCResourcePile/map-fetcher/commit/48b9fd9aa8528715129b3887b276c417e7322eab

Limitations of this is that we have to assume where the include file will be stored. If a map has an include file but that repo (or maintainer) isn't maintaining their own include files it can fall-back to our own repo. A further improvement would be checking that the include file exists where we assume it would be, then otherwise linking to our own.

![xml](https://user-images.githubusercontent.com/6386297/208892176-1fba7a06-dff4-49a5-bd14-0d91cff8b1bd.PNG)
