### PR TITLE
Fix incorrect XML includes URLs

### DIFF
--- a/src/data/maps/includes.json
+++ b/src/data/maps/includes.json
@@ -126,19 +126,19 @@
                 }, {
                     "title": "king-classes.xml",
                     "description": "Standard kits and settings for King's Conquest themed maps",
-                    "url": "https://github.com/MCResourcePile/overcast-includes/raw/master/gamemodes/king-classes.xml"
+                    "url": "https://github.com/MCResourcePile/overcast-includes/raw/master/gamemodes/arcade/king-classes.xml"
                 }, {
                     "title": "king-classes-easter.xml",
                     "description": "Easter themed kits and settings for King's Conquest themed maps",
-                    "url": "https://github.com/MCResourcePile/overcast-includes/raw/master/gamemodes/king-classes-easter.xml"
+                    "url": "https://github.com/MCResourcePile/overcast-includes/raw/master/gamemodes/arcade/king-classes-easter.xml"
                 }, {
                     "title": "king-classes-halloween.xml",
                     "description": "Halloween themed kits and settings for King's Conquest themed maps",
-                    "url": "https://github.com/MCResourcePile/overcast-includes/raw/master/gamemodes/king-classes-halloween.xml"
+                    "url": "https://github.com/MCResourcePile/overcast-includes/raw/master/gamemodes/arcade/king-classes-halloween.xml"
                 }, {
                     "title": "mmclasses.xml",
                     "description": "Standard kits and settings for Monster Mash themed maps",
-                    "url": "https://github.com/MCResourcePile/overcast-includes/raw/master/gamemodes/mmclasses.xml"
+                    "url": "https://github.com/MCResourcePile/overcast-includes/raw/master/gamemodes/arcade/mmclasses.xml"
                 }, {
                     "title": "void-death.xml",
                     "description": "Provides quicker deaths by the void",


### PR DESCRIPTION
The URLs for the King's Conquest (and its seasonal variants) and Monster Mash includes don't have the ``arcade`` folder in their path, so clicking on them takes you to a 404 page