### PR TITLE
Fix/update Monster Mash maps

### DIFF
--- a/src/data/maps/overcast.json
+++ b/src/data/maps/overcast.json
@@ -8940,7 +8940,7 @@
             "name": "MM: Crossroad",
             "slug": "mm_crossroad",
             "authors": [
-                {"username": "Reshif", "uuid": "459fd919-0d58-401a-9601-6cab1eb721ab"}
+                {"username": "Strangey", "uuid": "621b2aa8-4e5f-4ed8-bd36-0ae2f8952a06"}
             ],
             "tags": ["mm"],
             "commercial": true,
@@ -8950,7 +8950,7 @@
             "name": "MM: Dark Scent",
             "slug": "mm_dark_scent",
             "authors": [
-                {"username": "Reshif", "uuid": "459fd919-0d58-401a-9601-6cab1eb721ab"}
+                {"username": "Tywnis", "uuid": "2ca8072f-74be-4798-85b8-bbce03aa91af"}
             ],
             "tags": ["mm"],
             "commercial": true,
@@ -8960,7 +8960,7 @@
             "name": "MM: Decay",
             "slug": "mm_decay",
             "authors": [
-                {"username": "Jtr", "uuid": "105f6a09-f533-412b-93cb-501601763c11"}
+                {"username": "LoksHausmeister", "uuid": "105f6a09-f533-412b-93cb-501601763c11"}
             ],
             "tags": ["mm"],
             "commercial": true,
@@ -9010,7 +9010,7 @@
             "name": "MM: Lotus",
             "slug": "mm_lotus",
             "authors": [
-                {"username": "Reshif", "uuid": "459fd919-0d58-401a-9601-6cab1eb721ab"}
+                {"username": "givebigboy", "uuid": "dbc98e9b-c799-4fde-8284-9b09970a84a9"}
             ],
             "tags": ["mm"],
             "commercial": true,
@@ -9027,8 +9027,8 @@
             "download": true,
             "xml": true
         }, {
-            "name": "MM: Quary",
-            "slug": "mm_quary",
+            "name": "MM: Quarry",
+            "slug": "mm_quarry",
             "authors": [
                 {"username": "Reshif", "uuid": "459fd919-0d58-401a-9601-6cab1eb721ab"}
             ],
@@ -9040,7 +9040,7 @@
             "name": "MM: Rig",
             "slug": "mm_rig",
             "authors": [
-                {"username": "StealthMedia", "uuid": "2a289d2a-d970-49c5-9a6c-01fc0264e317"}
+                {"username": "khasmech", "uuid": "2a289d2a-d970-49c5-9a6c-01fc0264e317"}
             ],
             "tags": ["mm"],
             "commercial": true,


### PR DESCRIPTION
- Fixes attribution of some MM maps
- Updates some usernames
- Fixes MM: Quarry's name and slug so it can be downloaded (it has the correct name here: https://github.com/MCResourcePile/overcast-maps/blob/master/maps/mm_quarry/map.xml)