### PR TITLE
Use new PGM server guide link

### DIFF
--- a/src/data/global.json
+++ b/src/data/global.json
@@ -87,7 +87,7 @@
             "environments": {
                 "pgm": {
                     "label": "PGM",
-                    "message": "This map has been specifically designed and tested to be used with the maintained <a href=\"https://github.com/PGMDev/PGM\" target=\"_blank\">PGMDev</a> version of PGM (PvP Game Manager). ResourcePile recommends that you use the most up-to-date version of this PGM in order to have the best experience with this map.<br/><br/>To setup your own PGM server, please follow <a href=\"https://github.com/PGMDev/PGM/blob/dev/docs/RUNNING.md\" target=\"_blank\">this guide</a>. Further PGM support can be found in the <a href=\"https://discord.gg/pEEcwTk\" target=\"_blank\">PGM Discord</a>."
+                    "message": "This map has been specifically designed and tested to be used with the maintained <a href=\"https://github.com/PGMDev/PGM\" target=\"_blank\">PGMDev</a> version of PGM (PvP Game Manager). ResourcePile recommends that you use the most up-to-date version of this PGM in order to have the best experience with this map.<br/><br/>To setup your own PGM server, please follow <a href=\"https://pgm.dev/docs/guides/preparing/local-server-setup\" target=\"_blank\">this guide</a>. Further PGM support can be found in the <a href=\"https://discord.gg/pEEcwTk\" target=\"_blank\">PGM Discord</a>."
                 },
                 "pgm_legacy": {
                     "label": "PGM (Legacy)",


### PR DESCRIPTION
I noticed that MCResourcepile still links to the RUNNING.MD file for server setup. I've opened this pull request as I think the link to PGM Docs would be far more helpful for new and advanced users alike, as it goes in more depth about setting up a SportPaper server with PGM.