### PR TITLE
Fix a couple of typos in tournament pages

### DIFF
--- a/src/data/tournaments/overcast/raiders_of_the_lost_wool.json
+++ b/src/data/tournaments/overcast/raiders_of_the_lost_wool.json
@@ -70,7 +70,7 @@
     },
     "videos": [
         {"service": "youtube", "type": "playlist", "id": "PLkMxjxgmDw3osFJB5u70IGKO-HGvMsGXt", "title": "dewtroid's Stream", "description": "Playlist of dewtroit's stream of the tournament."},
-        {"service": "youtube", "type": "playlist", "id": "PLq5FGiBGWcKdqu_n2T7GRjUSHdRkOe-jM", "title": "Nadastrom's Stream", "description": "Playlist of Nadastorm's stream of the tournament."}
+        {"service": "youtube", "type": "playlist", "id": "PLq5FGiBGWcKdqu_n2T7GRjUSHdRkOe-jM", "title": "Nadastorm's Stream", "description": "Playlist of Nadastorm's stream of the tournament."}
     ],
     "maps": [
         {

--- a/src/data/tournaments/overcast/return_of_the_hill.json
+++ b/src/data/tournaments/overcast/return_of_the_hill.json
@@ -143,8 +143,8 @@
             "tags": ["ctw"]
         },
         {
-            "name": "Virtex",
-            "slug": "virtex",
+            "name": "Vitrex",
+            "slug": "vitrex",
             "tags": ["ctw"]
         },
         {


### PR DESCRIPTION
- Fix Nadastorm's name in Raiders of the Lost Wool

- The mysterious map in Return of the Hill called "Virtex" is actually Vitrex by Pandaboy999 (VCRHeadCleaner) - couldn't find it on the OCN website but it must be out there somewhere. Did find a video on it: https://www.youtube.com/watch?v=5rgOn3-oqSE