### PR TITLE
Fix some Avicus map names

### DIFF
--- a/src/data/maps/avicus.json
+++ b/src/data/maps/avicus.json
@@ -1681,7 +1681,7 @@
             "download": true,
             "xml": true
         }, {
-            "name": "Operation Deset Storm CTF",
+            "name": "Operation: Desert Storm CTF",
             "slug": "operation_desert_storm_ctf",
             "authors": [
                 {"username": "ProfessorUtonium", "uuid": "3cce0080-9faa-48f9-82cf-64410305822a"},
@@ -1692,7 +1692,7 @@
             "download": true,
             "xml": true
         }, {
-            "name": "Operation Deset Storm",
+            "name": "Operation: Desert Storm",
             "slug": "operation_desert_storm",
             "authors": [
                 {"username": "ProfessorUtonium", "uuid": "3cce0080-9faa-48f9-82cf-64410305822a"},
@@ -1723,7 +1723,7 @@
             "download": true,
             "xml": true
         }, {
-            "name": "Operation Winter Storm",
+            "name": "Operation: Winter Storm",
             "slug": "operation_winter_storm",
             "authors": [
                 {"username": "ProfessorUtonium", "uuid": "3cce0080-9faa-48f9-82cf-64410305822a"}
@@ -1733,7 +1733,7 @@
             "download": true,
             "xml": true
         }, {
-            "name": "Operation Winter Storm UHC",
+            "name": "Operation: Winter Storm UHC",
             "slug": "operation_winter_storm_uhc",
             "authors": [
                 {"username": "ProfessorUtonium", "uuid": "3cce0080-9faa-48f9-82cf-64410305822a"}


### PR DESCRIPTION
Fixes `Deset` in ``Operation: Desert Storm`` and ``Operation: Desert Storm CTF``, and adds ``:`` to all Operation maps (as their XML have them).

Funnily enough, the XML of the UHC Winter Storm has a typo and is called "Operation: Winter Storm HC" ingame